### PR TITLE
android: build for x86, x86_64, arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Node.js on Mobile
 
 This project is an experimental fork of [nodejs/node-chakracore](https://github.com/nodejs/node-chakracore) bringing Node.js to mobile operating systems, as a library that can be embedded in mobile applications and frameworks.
 
-It currently only builds for Android (with V8), as a shared library for the `armeabi-v7a` architecture. Support for iOS and additional Android architectures are in the works and will be published soon.
+It currently only builds for Android (with V8), as a shared library for the `armeabi-v7a`, `x86`, `arm64-v8a` and `x86_64` architectures. Support for iOS is in the works and will be published soon.
 
 ##### Project Goals
 The goals of this project are:
@@ -73,14 +73,14 @@ git checkout mobile-master
 
 #### 2a) Using the Android helper script:
 
-The `tools/android_build.sh` script takes as first argument the Android NDK path (in our case is `~/android-ndk-r15c`). The second argument is optional and is the target architecture, by default is `arm`.
+The `tools/android_build.sh` script takes as first argument the Android NDK path (in our case is `~/android-ndk-r15c`). The second argument is optional and is the target architecture, which can be one of the following: `arm`, `x86`, `arm64` or `x86_64`. If no target architecture is provided, it will build all available architectures.
 Run:
 
 ```sh
 ./tools/android_build.sh ~/android-ndk-r15c
 ```
 
-When done, the built shared library will be placed in `out_android/arm/libnode.so`.
+When done, each built shared library will be placed in `out_android/$(ARCHITECTURE)/libnode.so`.
 
 #### 2b) Configure and build manually:
 Run the `android-configure` script to configure the build with the path to the downloaded NDK and the desired target architecture.

--- a/android-configure
+++ b/android-configure
@@ -19,16 +19,19 @@ CC_VER="4.9"
 case $ARCH in
     arm)
         DEST_CPU="$ARCH"
+        V8_ARCH="$ARCH"
         SUFFIX="$ARCH-linux-androideabi"
         TOOLCHAIN_NAME="$SUFFIX"
         ;;
     x86)
         DEST_CPU="ia32"
+        V8_ARCH="ia32"
         SUFFIX="i686-linux-android"
         TOOLCHAIN_NAME="$ARCH"
         ;;
     x86_64)
         DEST_CPU="ia32"
+        V8_ARCH="ia32"
         SUFFIX="$ARCH-linux-android"
         TOOLCHAIN_NAME="$ARCH"
         ;;
@@ -67,7 +70,7 @@ export CXX=$TOOLCHAIN/bin/$SUFFIX-clang++
 export LINK=$TOOLCHAIN/bin/$SUFFIX-clang++
 
 GYP_DEFINES="target_arch=$ARCH"
-GYP_DEFINES+=" v8_target_arch=$ARCH"
+GYP_DEFINES+=" v8_target_arch=$V8_ARCH"
 GYP_DEFINES+=" android_target_arch=$ARCH"
 if [ "$(uname -s)" == "Darwin" ]; then
     GYP_DEFINES+=" host_os=mac OS=android"

--- a/android-configure
+++ b/android-configure
@@ -35,6 +35,12 @@ case $ARCH in
         SUFFIX="$ARCH-linux-android"
         TOOLCHAIN_NAME="$ARCH"
         ;;
+    arm64)
+        DEST_CPU="arm64"
+        V8_ARCH="arm64"
+        SUFFIX="aarch64-linux-android"
+        TOOLCHAIN_NAME="aarch64"
+        ;;
     *)
         echo "Unsupported architecture provided: $ARCH"
         exit 1

--- a/android-configure
+++ b/android-configure
@@ -30,8 +30,8 @@ case $ARCH in
         TOOLCHAIN_NAME="$ARCH"
         ;;
     x86_64)
-        DEST_CPU="ia32"
-        V8_ARCH="ia32"
+        DEST_CPU="x64"
+        V8_ARCH="x64"
         SUFFIX="$ARCH-linux-android"
         TOOLCHAIN_NAME="$ARCH"
         ;;

--- a/tools/android_build.sh
+++ b/tools/android_build.sh
@@ -34,10 +34,17 @@ BUILD_ARCH() {
 if [ $# -eq 2 ]
 then
   TARGET_ARCH=$2
+  BUILD_ARCH
 else
   TARGET_ARCH="arm"
+  BUILD_ARCH
+  TARGET_ARCH="x86"
+  BUILD_ARCH
+  TARGET_ARCH="arm64"
+  BUILD_ARCH
+  TARGET_ARCH="x86_64"
+  BUILD_ARCH
 fi
-BUILD_ARCH
 
 cd "$ROOT"
 


### PR DESCRIPTION
Fixes building for the Android x86 and x86_64 architectures and adds arm64 to the `android-configure` script.

Adds all available architectures to the helper script `tools/android_build.sh`.

Changes `README.md` to mention all architectures.
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tested built binaries on all platforms
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
android, doc