### PR TITLE
ios: build fix and add universal framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ xcuserdata/
 *.xcuserstate
 project.xcworkspace
 tools/ios-framework/bin/
+out_ios/
+out_android/
 
 # libuv book and GitHub template
 deps/uv/.github/

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ clean:
 	@if [ -d out ]; then find out/ -name '*.o' -o -name '*.a' -o -name '*.d' | xargs $(RM) -r; fi
 	$(RM) -r node_modules
 	@if [ -d deps/icu ]; then echo deleting deps/icu; $(RM) -r deps/icu; fi
+	@if [ -d deps/chakrashim/core/out ]; then echo deleting deps/chakrashim/core/out; $(RM) -r deps/chakrashim/core/out; fi
 	$(RM) test.tap
 
 distclean:

--- a/README.md
+++ b/README.md
@@ -149,13 +149,14 @@ git checkout mobile-master
 ./tools/ios_framework_prepare.sh
 ```
 
-That will configure `gyp` to build Node.js and its dependencies as static libraries for iOS on the arm64 architecture, using the `ChakraCore` engine with JIT disabled. It will then copy those libraries into `tools/ios-framework/bin/`, to be used by the `nodeLib.xcodeproj` Xcode project.
+That will configure `gyp` to build Node.js and its dependencies as static libraries for iOS on the arm64 and x64 architectures, using the `ChakraCore` engine with JIT disabled. The script copies those libraries to `tools/ios-framework/bin/arm64` and `tools/ios-framework/bin/x64`, respectively. It also merges them into static libraries that contain strips for both architectures, which will be placed in `tools/ios-framework/bin` and used by the `tools/ios-framework/nodeLib.xcodeproj` Xcode project.
 
-#### 3) Build the iOS Framework:
+The helper script builds the `tools/ios-framework/nodeLib.xcodeproj` Xcode project into three frameworks:
+  - The framework to run on iOS devices: `out_ios/Release-iphoneos/libnode.framework`
+  - The framework to run on the iOS simulator: `out_ios/Release-iphonesimulator/libnode.framework`
+  - The universal framework, that runs on iOS devices and simulators: `out_ios/Release-universal/libnode.framework`
 
-Open `tools/ios-framework/nodeLib.xcodeproj` in Xcode and build the project with either a physical device or `Generic iOS Device` selected as the build target. After building, you can check on Xcode's project browser that a `libnode.framework` file is created in `nodeLib/Products/`.
-
-Control click `libnode.framework` in Xcode and select `Show in finder`. This will show you where the built `libnode.framework` is. It should be inside a folder named `Debug-iphoneos`.
+While the universal framework is useful for faster Application development, due to supporting both iOS devices and simulators, frameworks containing simulator strips will not be accepted on the App Store. Before trying to submit your application, it would be advisable to use the `Release-iphoneos/libnode.framework` in your submission archive or strip the x64 slices from the universal framework's binaries before submitting.
 
 ## Contributing
 Please see the [CONTRIBUTING](https://github.com/janeasystems/nodejs-mobile/blob/mobile-master/doc_mobile/CONTRIBUTING.md) file in the `doc_mobile` folder in this source distribution.

--- a/deps/chakrashim/chakracore.gyp
+++ b/deps/chakrashim/chakracore.gyp
@@ -17,7 +17,10 @@
 
     'conditions': [
       ['target_arch=="ia32"', { 'Platform': 'x86' }],
-      ['target_arch=="x64"', { 'Platform': 'x64' }],
+      ['target_arch=="x64"', {
+        'Platform': 'x64',
+        'chakra_build_flags+': [ '--arch=amd64' ],
+      }],
       ['target_arch=="arm"', {
         'Platform': 'arm',
       }],

--- a/deps/chakrashim/core/Build/CMakeFeatureDetect.cmake
+++ b/deps/chakrashim/core/Build/CMakeFeatureDetect.cmake
@@ -13,7 +13,7 @@ if(CC_TARGET_OS_OSX OR CC_TARGET_OS_IOS)
         -Werror"
         )
 endif()
-if (CC_TARGET_OS_IOS AND CC_TARGETS_ARM64)
+if (CC_TARGET_OS_IOS)
   # Can't run the test when cross_compiling, so the flag is set manually.
   set(CLANG_HAS_DISABLE_TAIL_CALLS_CFG 1)
 else()

--- a/deps/chakrashim/core/CMakeLists.txt
+++ b/deps/chakrashim/core/CMakeLists.txt
@@ -255,20 +255,20 @@ elseif(CC_TARGET_OS_OSX OR CC_TARGET_OS_IOS)
             #iOS Physical device.
             add_compile_options(-miphoneos-version-min=11.0)
             # isysroot is the result from running -> xcodebuild -version -sdk iphoneos Path
-            add_compile_options(-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk)
+            add_compile_options(-isysroot ${CMAKE_IOS_SDK_ROOT})
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
-              -miphoneos-version-min=11.0 -fembed-bitcode -std=gnu99 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk")
+              -miphoneos-version-min=11.0 -fembed-bitcode -std=gnu99 -isysroot ${CMAKE_IOS_SDK_ROOT}")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-              -miphoneos-version-min=11.0 -fembed-bitcode -std=gnu++11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.0.sdk")
+              -miphoneos-version-min=11.0 -fembed-bitcode -std=gnu++11 -isysroot ${CMAKE_IOS_SDK_ROOT}")
           else()
             #iOS Simulator.
             add_compile_options(-mios-simulator-version-min=11.0)
             # isysroot is the result from running -> xcodebuild -version -sdk iphonesimulator Path
-            add_compile_options(-isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.0.sdk)
+            add_compile_options(-isysroot ${CMAKE_IOS_SDK_ROOT})
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} \
-              -mios-simulator-version-min=11.0 -std=gnu99 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.0.sdk")
+              -mios-simulator-version-min=11.0 -std=gnu99 -isysroot ${CMAKE_IOS_SDK_ROOT}")
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
-              -mios-simulator-version-min=11.0 -std=gnu++11 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.0.sdk")
+              -mios-simulator-version-min=11.0 -std=gnu++11 -isysroot ${CMAKE_IOS_SDK_ROOT}")
           endif()
         else()
           set(IOS_DEPLOYMENT_TARGET "$ENV{IPHONEOS_DEPLOYMENT_TARGET}")

--- a/deps/chakrashim/core/build.sh
+++ b/deps/chakrashim/core/build.sh
@@ -116,7 +116,7 @@ CMAKE_EXPORT_COMPILE_COMMANDS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
 LIBS_ONLY_BUILD=
 SHOULD_EMBED_ICU=0
 ALWAYS_YES=0
-CMAKE_SKIP_CHECK_COMPILER=""
+CMAKE_ADD_IOS_TOOLCHAIN=""
 
 if [ -f "/proc/version" ]; then
     OS_LINUX=1
@@ -289,7 +289,8 @@ while [[ $# -gt 0 ]]; do
         if [[ $_TARGET_OS =~ "ios" ]]; then
           TARGET_OS="-DCC_TARGET_OS_IOS_SH=1"
           #In order to make cmake cross compile correctly, a toolchain file is referenced.
-          CMAKE_SKIP_CHECK_COMPILER="-DCMAKE_TOOLCHAIN_FILE=ios.cmake"
+          CMAKE_ADD_IOS_TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=ios.cmake"
+
         fi
         ;;
 
@@ -593,12 +594,20 @@ if [[ $ARCH =~ "x86" ]]; then
 elif [[ $ARCH =~ "arm64" ]]; then
     ARCH="-DCC_TARGETS_ARM64_SH=1"
     echo "Compile Target : arm64"
+    if [[ $TARGET_OS =~ "-DCC_TARGET_OS_IOS_SH=1" ]]; then
+        #Pass IOS_PLATFORM to ios.cmake
+        CMAKE_ADD_IOS_TOOLCHAIN="$CMAKE_ADD_IOS_TOOLCHAIN -DIOS_PLATFORM=OS"
+    fi
 elif [[ $ARCH =~ "arm" ]]; then
     ARCH="-DCC_TARGETS_ARM_SH=1"
     echo "Compile Target : arm"
 elif [[ $ARCH =~ "amd64" ]]; then
     ARCH="-DCC_TARGETS_AMD64_SH=1"
     echo "Compile Target : amd64"
+    if [[ $TARGET_OS =~ "-DCC_TARGET_OS_IOS_SH=1" ]]; then
+        #Pass IOS_PLATFORM to ios.cmake
+        CMAKE_ADD_IOS_TOOLCHAIN="$CMAKE_ADD_IOS_TOOLCHAIN -DIOS_PLATFORM=SIMULATOR64"
+    fi
 else
     echo "Compile Target : System Default"
 fi
@@ -608,7 +617,7 @@ echo $EXTRA_DEFINES
 cmake $CMAKE_GEN $CC_PREFIX $ICU_PATH $LTO $STATIC_LIBRARY $ARCH $TARGET_OS \
     $ENABLE_CC_XPLAT_TRACE $EXTRA_DEFINES -DCMAKE_BUILD_TYPE=$BUILD_TYPE $SANITIZE $NO_JIT $INTL_ICU \
     $WITHOUT_FEATURES $WB_FLAG $WB_ARGS $CMAKE_EXPORT_COMPILE_COMMANDS $LIBS_ONLY_BUILD\
-    $CMAKE_SKIP_CHECK_COMPILER $VALGRIND $BUILD_RELATIVE_DIRECTORY
+    $CMAKE_ADD_IOS_TOOLCHAIN $VALGRIND $BUILD_RELATIVE_DIRECTORY
 
 _RET=$?
 if [[ $? == 0 ]]; then

--- a/deps/chakrashim/core/lib/Common/CommonDefines.h
+++ b/deps/chakrashim/core/lib/Common/CommonDefines.h
@@ -153,7 +153,7 @@
 #else
 #define SYSINFO_IMAGE_BASE_AVAILABLE 0
 #ifndef ENABLE_VALGRIND
-#if defined(__IOS__)&&defined(_M_ARM64)
+#if defined(__IOS__)
 //FIXME: Disabled concurrent garbage collection, which seems to require
 // RECYCLER_WRITE_BARRIER, and that is not feasable on a 18 exabyte
 // VM address space.
@@ -161,7 +161,7 @@
 #else
 #define ENABLE_CONCURRENT_GC 1
 #define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 1 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.
-#endif //defined(__IOS__)&&defined(_M_ARM64)
+#endif //defined(__IOS__)
 #else
 #define ENABLE_CONCURRENT_GC 0
 #define ENABLE_ALLOCATIONS_DURING_CONCURRENT_SWEEP 0 // Only takes effect when ENABLE_CONCURRENT_GC is enabled.

--- a/deps/chakrashim/core/pal/src/debug/debug.cpp
+++ b/deps/chakrashim/core/pal/src/debug/debug.cpp
@@ -47,8 +47,8 @@ Revision History:
 #include <unistd.h>
 #elif HAVE_TTRACE // HAVE_PROCFS_CTL
 #include <sys/ttrace.h>
-#elif !(defined(__IOS__) && defined(_M_ARM64)) // HAVE_TTRACE
-//FIXME: Removed to build for iOS ARM64.
+#elif !defined(__IOS__) // HAVE_TTRACE
+//FIXME: Removed to build for iOS.
 #include <sys/ptrace.h>
 #endif  // HAVE_PROCFS_CTL
 #if HAVE_VM_READ

--- a/deps/chakrashim/core/pal/src/misc/sysinfo.cpp
+++ b/deps/chakrashim/core/pal/src/misc/sysinfo.cpp
@@ -53,7 +53,8 @@ Revision History:
 #include <mach/mach_host.h>
 #endif // defined(__APPLE__)
 
-#if !(defined(__IOS__) && defined(_M_ARM64))
+#if !defined(__IOS__)
+//FIXME: Removed to build for iOS.
 // On some platforms sys/user.h ends up defining _DEBUG; if so
 // remove the definition before including the header and put
 // back our definition afterwards
@@ -67,7 +68,7 @@ Revision History:
 #define _DEBUG OLD_DEBUG
 #undef OLD_DEBUG
 #endif
-#endif // !(defined(__IOS__) && defined(_M_ARM64))
+#endif // !defined(__IOS__)
 
 #include "pal/dbgmsg.h"
 
@@ -104,7 +105,7 @@ SET_DEFAULT_DEBUG_CHANNEL(MISC);
 #endif // __LINUX__
 
 #ifdef __IOS__
-#ifdef _M_ARM64
+#ifdef BIT64
 // This is the size of the virtual address space on 64 bits IOS,
 // according to Apple, is 18 exabytes.
 #define MAX_PROCESS_VA_SPACE_IOS64 \
@@ -182,7 +183,7 @@ GetSystemInfo(
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) VM_MAXUSER_ADDRESS;
 #elif defined(__LINUX__)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) MAX_PROCESS_VA_SPACE_LINUX;
-#elif defined(__IOS__)&&defined(_M_ARM64)
+#elif defined(__IOS__)&&defined(BIT64)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) MAX_PROCESS_VA_SPACE_IOS64;
 #elif defined(USERLIMIT)
     lpSystemInfo->lpMaximumApplicationAddress = (PVOID) USERLIMIT;

--- a/deps/chakrashim/core/pal/src/thread/context.cpp
+++ b/deps/chakrashim/core/pal/src/thread/context.cpp
@@ -11,8 +11,8 @@ SET_DEFAULT_DEBUG_CHANNEL(THREAD); // some headers have code with asserts, so do
 #include "pal/debug.h"
 #include "pal/thread.hpp"
 
-#if !(defined(__IOS__) && defined(_M_ARM64))
-//FIXME: Removed to build for iOS ARM64.
+#if !defined(__IOS__)
+//FIXME: Removed to build for iOS.
 #include <sys/ptrace.h>
 #endif
 #include <errno.h>

--- a/tools/ios-framework/nodeLib.xcodeproj/project.pbxproj
+++ b/tools/ios-framework/nodeLib.xcodeproj/project.pbxproj
@@ -333,7 +333,7 @@
 				SEPARATE_STRIP = YES;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
-				VALID_ARCHS = arm64;
+				VALID_ARCHS = "arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -370,7 +370,7 @@
 				SEPARATE_STRIP = YES;
 				SKIP_INSTALL = YES;
 				STRIP_STYLE = "non-global";
-				VALID_ARCHS = arm64;
+				VALID_ARCHS = "arm64 x86_64";
 			};
 			name = Release;
 		};

--- a/tools/ios_framework_prepare.sh
+++ b/tools/ios_framework_prepare.sh
@@ -12,7 +12,10 @@ SCRIPT_DIR=${PWD}
 cd ../
 
 LIBRARY_PATH='out/Release'
-TARGET_LIBRARY_PATH='tools/ios-framework/bin'
+
+make clean
+
+TARGET_LIBRARY_PATH='tools/ios-framework/bin/arm64'
 
 ./configure --dest-os=ios --dest-cpu=arm64 --without-chakra-jit --enable-static --with-intl=none --openssl-no-asm
 make
@@ -28,5 +31,51 @@ cp $LIBRARY_PATH/libnode.a $TARGET_LIBRARY_PATH/
 cp $LIBRARY_PATH/libopenssl.a $TARGET_LIBRARY_PATH/
 cp $LIBRARY_PATH/libuv.a $TARGET_LIBRARY_PATH/
 cp $LIBRARY_PATH/libzlib.a $TARGET_LIBRARY_PATH/
+
+make clean
+
+TARGET_LIBRARY_PATH='tools/ios-framework/bin/x64'
+
+./configure --dest-os=ios --dest-cpu=x64 --without-chakra-jit --enable-static --with-intl=none --openssl-no-asm
+make
+
+mkdir -p $TARGET_LIBRARY_PATH
+
+cp $LIBRARY_PATH/libcares.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libChakraCoreStatic.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libchakrashim.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libhttp_parser.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libnghttp2.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libnode.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libopenssl.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libuv.a $TARGET_LIBRARY_PATH/
+cp $LIBRARY_PATH/libzlib.a $TARGET_LIBRARY_PATH/
+
+TARGET_LIBRARY_PATH='tools/ios-framework/bin'
+
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libcares.a" "$TARGET_LIBRARY_PATH/x64/libcares.a" -output "$TARGET_LIBRARY_PATH/libcares.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libChakraCoreStatic.a" "$TARGET_LIBRARY_PATH/x64/libChakraCoreStatic.a" -output "$TARGET_LIBRARY_PATH/libChakraCoreStatic.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libchakrashim.a" "$TARGET_LIBRARY_PATH/x64/libchakrashim.a" -output "$TARGET_LIBRARY_PATH/libchakrashim.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libhttp_parser.a" "$TARGET_LIBRARY_PATH/x64/libhttp_parser.a" -output "$TARGET_LIBRARY_PATH/libhttp_parser.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libnghttp2.a" "$TARGET_LIBRARY_PATH/x64/libnghttp2.a" -output "$TARGET_LIBRARY_PATH/libnghttp2.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libnode.a" "$TARGET_LIBRARY_PATH/x64/libnode.a" -output "$TARGET_LIBRARY_PATH/libnode.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libopenssl.a" "$TARGET_LIBRARY_PATH/x64/libopenssl.a" -output "$TARGET_LIBRARY_PATH/libopenssl.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libuv.a" "$TARGET_LIBRARY_PATH/x64/libuv.a" -output "$TARGET_LIBRARY_PATH/libuv.a"
+lipo -create "$TARGET_LIBRARY_PATH/arm64/libzlib.a" "$TARGET_LIBRARY_PATH/x64/libzlib.a" -output "$TARGET_LIBRARY_PATH/libzlib.a"
+
+#Create a path to build the frameworks into
+mkdir -p out_ios
+cd out_ios
+FRAMEWORK_TARGET_DIR=${PWD}
+cd ../
+
+NODELIB_PROJECT_PATH='tools/ios-framework'
+
+xcodebuild build -project $NODELIB_PROJECT_PATH/nodeLib.xcodeproj -target "libnode" -configuration Release -arch arm64 -sdk "iphoneos" SYMROOT=$FRAMEWORK_TARGET_DIR
+xcodebuild build -project $NODELIB_PROJECT_PATH/nodeLib.xcodeproj -target "libnode" -configuration Release -arch x86_64 -sdk "iphonesimulator" SYMROOT=$FRAMEWORK_TARGET_DIR
+cp -RL $FRAMEWORK_TARGET_DIR/Release-iphoneos $FRAMEWORK_TARGET_DIR/Release-universal
+lipo -create $FRAMEWORK_TARGET_DIR/Release-iphoneos/libnode.framework/libnode $FRAMEWORK_TARGET_DIR/Release-iphonesimulator/libnode.framework/libnode -output $FRAMEWORK_TARGET_DIR/Release-universal/libnode.framework/libnode
+
+echo "Frameworks built to $FRAMEWORK_TARGET_DIR"
 
 cd "$ROOT"


### PR DESCRIPTION
This PR addresses the following issues:
- Remove fixed path for the iOS sdk from ChakraCore build systems.
- Add instruction to `make clean` to delete ChakraCore's CMake output between builds.
- Add support for a `x86_64` architecture build of Node.js for the iOS simulator.
- Helper script builds iOS static libraries with `arm64` and `x86_64` strips.
- Helper script builds 64 bits `libnode.framework` in three formats: `iphoneos`,`iphonesimulator` and `universal`.
- Update iOS build instructions to take the changes into account.

##### Affected core subsystem(s)
ios, build, docs