### PR TITLE
ios,os: set CPU speed to 0 in os.cpus

### DIFF
--- a/deps/uv/src/unix/darwin.c
+++ b/deps/uv/src/unix/darwin.c
@@ -186,7 +186,12 @@ int uv_cpu_info(uv_cpu_info_t** cpu_infos, int* count) {
 
   size = sizeof(cpuspeed);
   if (sysctlbyname("hw.cpufrequency", &cpuspeed, &size, NULL, 0))
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
+    // You can't get cpu frequency on iOS devices. Defaults to 0.
+    cpuspeed = 0;
+#else
     return -errno;
+#endif
 
   if (host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numcpus,
                           (processor_info_array_t*)&info,


### PR DESCRIPTION
On iOS, reading the CPU frequency in devices is not allowed, so `os.cpus` `speed` values of all processors are set to 0, analogous to the behavior of the time.nice values on Windows.

Fixes: https://github.com/janeasystems/nodejs-mobile/issues/20

##### Checklist
- [x] tested on iOS device
- [x] commit message follows commit guidelines

##### Affected core subsystem(s)
os, ios