### PR TITLE
ChakraCore: Fix build script for LLVM >9

### DIFF
--- a/deps/chakrashim/core/build.sh
+++ b/deps/chakrashim/core/build.sh
@@ -495,7 +495,7 @@ else
 fi
 
 # check clang version (min required 3.7)
-VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]\.[0-9]*" --o)
+VERSION=$($CLANG_PATH --version | grep "version [0-9]*\.[0-9]*" --o -i | grep "[0-9]*\.[0-9]*" --o)
 VERSION=${VERSION/./}
 
 if [[ $VERSION -lt 37 ]]; then


### PR DESCRIPTION
Based on https://github.com/Microsoft/ChakraCore/commit/6ed4bab072a3a97db8a2a3cbe0bcbc7efd904608 by patrickkettner

Fixes #123 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like doc, cluster, crypto, etc). -->
ChakraCore