### PR TITLE
Added -fPIC to cflags in commong.gypi

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -170,7 +170,7 @@
         'variables': {
           'v8_enable_handle_zapping': 0,
         },
-        'cflags': [ '-O3' ],
+        'cflags': [ '-O3', '-fPIC'],
         'conditions': [
           ['target_arch=="x64"', {
             'msvs_configuration_platform': 'x64',


### PR DESCRIPTION
**Why**

The compiler was failing when linking the `grpc_node` module which is required by a `composer-admin` dependency. The error was:

```
[LIB 1 PATH OMITTED] requires unsupported dynamic reloc R_ARM_REL32; recompile with -fPIC
...
[LIB N PATH OMITTED] requires unsupported dynamic reloc R_ARM_REL32; recompile with -fPIC
clang70++: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [grpc_node.target.mk:189: Release/obj.target/grpc_node.node] Error 1
make: Leaving directory '/home/vanclief/Cacao_repos/react-app/android/build/nodejs-native-assets-temp-build/nodejs-native-assets-armeabi-v7a/nodejs-project/node_modules/fabric-client/node_modules/grpc/build'
```

The `-fPIC` flag is being used as an ldflag in the [common.gypi](https://github.com/janeasystems/nodejs-mobile-react-native/blob/ed727edea17e8a9e1a85cef3413becc83b8a0328/android/libnode/include/node/common.gypi), but it is required to be set as a cflag.


[This is the full error log](https://gist.github.com/Vanclief/518de77b69aea8cca29e64bdb24c829e)

Issue was solved after adding the flag.