### PR TITLE
ios: fix exception handling on iPhone A12 CPUs

### DIFF
--- a/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1425,1262 +1425,4185 @@ dbl_align:
 //        varResult = arm64_CallFunction((JavascriptFunction*)function, args.Info, args.Values, entryPoint);
 
         unsigned count = args.Info.Count;
-        switch(args.Info.Count) 
+        switch(args.Info.Count)
         {
             case 0:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info);
                 break;
             case 1:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0]);
                 break;
             case 2:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1]);
                 break;
             case 3:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2]);
                 break;
             case 4:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3]);
                 break;
             case 5:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4]);
                 break;
             case 6:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5]);
                 break;
             case 7:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info,  args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6]);
                 break;
             case 8:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info,  args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7]);
                 break;
             case 9:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8]);
                 break;
             case 10:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]);
                 break;
             case 11:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10]);
                 break;
             case 12:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11]);
                 break;
             case 13:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                             args.Values[10], args.Values[11], args.Values[12]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12]);
                 break;
             case 14:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                         args.Values[10], args.Values[11], args.Values[12], args.Values[13]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13]);
                 break;
             case 15:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14]);
                 break;
             case 16:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15]);
                 break;
             case 17:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16]);
                 break;
             case 18:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17]);
                 break;
             case 19:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18]);
                 break;
             case 20:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]);
                 break;
             case 21:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20]);
                 break;
             case 22:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21]);
                 break;
             case 23:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22]);
                 break;
             case 24:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23]);
                 break;
             case 25:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24]);
                 break;
             case 26:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25]);
                 break;
             case 27:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26]);
                 break;
             case 28:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27]);
                 break;
             case 29:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28]);
                 break;
             case 30:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]);
                 break;
             case 31:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30]);
                 break;
             case 32:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31]);
                 break;
             case 33:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32]);
                 break;
             case 34:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33]);
                 break;
             case 35:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34]);
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34]);
                 break;
             case 36:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35]);
                 break;
             case 37:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36]);
                 break;
             case 38:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37]);
                 break;
             case 39:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38]);
                 break;
             case 40:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]);
                 break;
             case 41:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40]);
                 break;
             case 42:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41]);
                 break;
             case 43:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42]);
                 break;
             case 44:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43]);
                 break;
             case 45:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44]);
                 break;
             case 46:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45]);
                 break;
             case 47:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46]);
                 break;
             case 48:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], 
-                                                                            args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47]);
                 break;
             case 49:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48]);
                 break;
             case 50:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]);
                 break;
             case 51:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50]);
                 break;
             case 52:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51]);
                 break;
             case 53:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52]);
                 break;
             case 54:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53]);
                 break;
             case 55:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54]);
                 break;
             case 56:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55]);
                 break;
             case 57:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56]);
                 break;
             case 58:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57]);
                 break;
             case 59:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58]);
                 break;
             case 60:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]); 
-               break;
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]);
+                break;
             case 61:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                                                                                    args.Values[60]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60]);
                 break;
             case 62:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61]);
                 break;
             case 63:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62]);
                 break;
             case 64:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63]);
                 break;
             case 65:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39],
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64]);
                 break;
             case 66:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65]);
                 break;
             case 67:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66]);
                 break;
             case 68:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67]);
                 break;
             case 69:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68]);
                 break;
             case 70:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39],
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]); 
-               break;    
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]);
+                break;
             case 71:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70]);
                 break;
             case 72:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71]);
                 break;
             case 73:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72]);
                 break;
             case 74:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73]);
                 break;
             case 75:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74]);
                 break;
             case 76:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75]);
                 break;
             case 77:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76]);
                 break;
             case 78:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77]);
                 break;
             case 79:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78]);
                 break;
             case 80:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]); 
-               break;                
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]);
+                break;
             case 81:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80]);
                 break;
             case 82:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81]);
                 break;
             case 83:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82]);
                 break;
             case 84:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83]);
                 break;
             case 85:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84]);
                 break;
             case 86:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85]);
                 break;
             case 87:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86]);
                 break;
             case 88:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87]);
                 break;
             case 89:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88]);
                 break;
             case 90:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]); 
-               break;  
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]);
+                break;
             case 91:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90]);
                 break;
             case 92:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91]);
                 break;
             case 93:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92]);
                 break;
             case 94:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93]);
                 break;
             case 95:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94]);
                 break;
             case 96:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95]);
                 break;
             case 97:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96]);
                 break;
             case 98:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97]);
                 break;
             case 99:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98]);
                 break;
             case 100:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]); 
-               break;                              
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]);
+                break;
             case 101:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100]);
                 break;
             case 102:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101]);
                 break;
             case 103:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102]);
                 break;
             case 104:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103]);
                 break;
             case 105:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104]);
                 break;
             case 106:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105]);
                 break;
             case 107:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106]);
                 break;
             case 108:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107]);
                 break;
             case 109:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108]);
                 break;
             case 110:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]); 
-               break;   
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]);
+                break;
             case 111:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110]);
                 break;
             case 112:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111]);
                 break;
             case 113:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112]);
                 break;
             case 114:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113]);
                 break;
             case 115:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114]);
                 break;
             case 116:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115]);
                 break;
             case 117:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116]);
                 break;
             case 118:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117]);
                 break;
             case 119:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118]);
                 break;
             case 120:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]); 
-               break;
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]);
+                break;
             case 121:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120]);
                 break;
             case 122:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121]);
                 break;
             case 123:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121], args.Values[122]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122]);
                 break;
             case 124:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123]);
                 break;
             case 125:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124]);
                 break;
             case 126:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125]); 
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125]);
                 break;
             case 127:
-                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
-                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
-                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
-                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
-                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
-                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
-                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
-                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
-                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
-                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
-                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
-                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126]); 
-               break;                                           
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126]);
+                break;
+            case 128:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127]);
+                break;
+            case 129:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128]);
+                break;
+            case 130:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]);
+                break;
+            case 131:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130]);
+                break;
+            case 132:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131]);
+                break;
+            case 133:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132]);
+                break;
+            case 134:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133]);
+                break;
+            case 135:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134]);
+                break;
+            case 136:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135]);
+                break;
+            case 137:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136]);
+                break;
+            case 138:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137]);
+                break;
+            case 139:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138]);
+                break;
+            case 140:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]);
+                break;
+            case 141:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140]);
+                break;
+            case 142:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141]);
+                break;
+            case 143:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142]);
+                break;
+            case 144:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143]);
+                break;
+            case 145:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144]);
+                break;
+            case 146:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145]);
+                break;
+            case 147:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146]);
+                break;
+            case 148:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147]);
+                break;
+            case 149:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148]);
+                break;
+            case 150:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]);
+                break;
+            case 151:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150]);
+                break;
+            case 152:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151]);
+                break;
+            case 153:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152]);
+                break;
+            case 154:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153]);
+                break;
+            case 155:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154]);
+                break;
+            case 156:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155]);
+                break;
+            case 157:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156]);
+                break;
+            case 158:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157]);
+                break;
+            case 159:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158]);
+                break;
+            case 160:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]);
+                break;
+            case 161:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160]);
+                break;
+            case 162:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161]);
+                break;
+            case 163:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162]);
+                break;
+            case 164:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163]);
+                break;
+            case 165:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164]);
+                break;
+            case 166:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165]);
+                break;
+            case 167:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166]);
+                break;
+            case 168:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167]);
+                break;
+            case 169:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168]);
+                break;
+            case 170:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]);
+                break;
+            case 171:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170]);
+                break;
+            case 172:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171]);
+                break;
+            case 173:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172]);
+                break;
+            case 174:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173]);
+                break;
+            case 175:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174]);
+                break;
+            case 176:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175]);
+                break;
+            case 177:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176]);
+                break;
+            case 178:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177]);
+                break;
+            case 179:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178]);
+                break;
+            case 180:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]);
+                break;
+            case 181:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180]);
+                break;
+            case 182:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181]);
+                break;
+            case 183:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182]);
+                break;
+            case 184:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183]);
+                break;
+            case 185:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184]);
+                break;
+            case 186:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185]);
+                break;
+            case 187:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186]);
+                break;
+            case 188:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187]);
+                break;
+            case 189:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188]);
+                break;
+            case 190:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]);
+                break;
+            case 191:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190]);
+                break;
+            case 192:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191]);
+                break;
+            case 193:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192]);
+                break;
+            case 194:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193]);
+                break;
+            case 195:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194]);
+                break;
+            case 196:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195]);
+                break;
+            case 197:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196]);
+                break;
+            case 198:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197]);
+                break;
+            case 199:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198]);
+                break;
+            case 200:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]);
+                break;
+            case 201:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200]);
+                break;
+            case 202:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201]);
+                break;
+            case 203:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202]);
+                break;
+            case 204:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203]);
+                break;
+            case 205:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204]);
+                break;
+            case 206:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205]);
+                break;
+            case 207:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206]);
+                break;
+            case 208:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207]);
+                break;
+            case 209:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208]);
+                break;
+            case 210:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]);
+                break;
+            case 211:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210]);
+                break;
+            case 212:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211]);
+                break;
+            case 213:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212]);
+                break;
+            case 214:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213]);
+                break;
+            case 215:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214]);
+                break;
+            case 216:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215]);
+                break;
+            case 217:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216]);
+                break;
+            case 218:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217]);
+                break;
+            case 219:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218]);
+                break;
+            case 220:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]);
+                break;
+            case 221:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220]);
+                break;
+            case 222:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221]);
+                break;
+            case 223:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222]);
+                break;
+            case 224:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223]);
+                break;
+            case 225:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224]);
+                break;
+            case 226:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225]);
+                break;
+            case 227:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226]);
+                break;
+            case 228:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227]);
+                break;
+            case 229:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228]);
+                break;
+            case 230:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]);
+                break;
+            case 231:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230]);
+                break;
+            case 232:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231]);
+                break;
+            case 233:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232]);
+                break;
+            case 234:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233]);
+                break;
+            case 235:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234]);
+                break;
+            case 236:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235]);
+                break;
+            case 237:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236]);
+                break;
+            case 238:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237]);
+                break;
+            case 239:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238]);
+                break;
+            case 240:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]);
+                break;
+            case 241:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240]);
+                break;
+            case 242:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241]);
+                break;
+            case 243:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242]);
+                break;
+            case 244:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243]);
+                break;
+            case 245:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244]);
+                break;
+            case 246:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245]);
+                break;
+            case 247:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246]);
+                break;
+            case 248:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247]);
+                break;
+            case 249:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248]);
+                break;
+            case 250:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]);
+                break;
+            case 251:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250]);
+                break;
+            case 252:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250], args.Values[251]);
+                break;
+            case 253:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250], args.Values[251], args.Values[252]);
+                break;
+            case 254:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250], args.Values[251], args.Values[252], args.Values[253]);
+                break;
+            case 255:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250], args.Values[251], args.Values[252], args.Values[253], args.Values[254]);
+                break;
+            case 256:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),entryPoint, (JavascriptFunction*)function, args.Info
+                    , args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]
+                    , args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]
+                    , args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]
+                    , args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]
+                    , args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]
+                    , args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]
+                    , args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]
+                    , args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]
+                    , args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]
+                    , args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]
+                    , args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]
+                    , args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]
+                    , args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126], args.Values[127], args.Values[128], args.Values[129]
+                    , args.Values[130], args.Values[131], args.Values[132], args.Values[133], args.Values[134], args.Values[135], args.Values[136], args.Values[137], args.Values[138], args.Values[139]
+                    , args.Values[140], args.Values[141], args.Values[142], args.Values[143], args.Values[144], args.Values[145], args.Values[146], args.Values[147], args.Values[148], args.Values[149]
+                    , args.Values[150], args.Values[151], args.Values[152], args.Values[153], args.Values[154], args.Values[155], args.Values[156], args.Values[157], args.Values[158], args.Values[159]
+                    , args.Values[160], args.Values[161], args.Values[162], args.Values[163], args.Values[164], args.Values[165], args.Values[166], args.Values[167], args.Values[168], args.Values[169]
+                    , args.Values[170], args.Values[171], args.Values[172], args.Values[173], args.Values[174], args.Values[175], args.Values[176], args.Values[177], args.Values[178], args.Values[179]
+                    , args.Values[180], args.Values[181], args.Values[182], args.Values[183], args.Values[184], args.Values[185], args.Values[186], args.Values[187], args.Values[188], args.Values[189]
+                    , args.Values[190], args.Values[191], args.Values[192], args.Values[193], args.Values[194], args.Values[195], args.Values[196], args.Values[197], args.Values[198], args.Values[199]
+                    , args.Values[200], args.Values[201], args.Values[202], args.Values[203], args.Values[204], args.Values[205], args.Values[206], args.Values[207], args.Values[208], args.Values[209]
+                    , args.Values[210], args.Values[211], args.Values[212], args.Values[213], args.Values[214], args.Values[215], args.Values[216], args.Values[217], args.Values[218], args.Values[219]
+                    , args.Values[220], args.Values[221], args.Values[222], args.Values[223], args.Values[224], args.Values[225], args.Values[226], args.Values[227], args.Values[228], args.Values[229]
+                    , args.Values[230], args.Values[231], args.Values[232], args.Values[233], args.Values[234], args.Values[235], args.Values[236], args.Values[237], args.Values[238], args.Values[239]
+                    , args.Values[240], args.Values[241], args.Values[242], args.Values[243], args.Values[244], args.Values[245], args.Values[246], args.Values[247], args.Values[248], args.Values[249]
+                    , args.Values[250], args.Values[251], args.Values[252], args.Values[253], args.Values[254], args.Values[255]);
+                break;
             default:
                 AssertMsg(false, "CallFunction call with unsupported number of arguments");
         }

--- a/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1419,7 +1419,237 @@ dbl_align:
 #endif
         Js::Var varResult;
 
-        varResult = arm64_CallFunction((JavascriptFunction*)function, args.Info, args.Values, entryPoint);
+        unsigned count = args.Info.Count;
+        switch(args.Info.Count) 
+        {
+            case 0:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info);
+                break;
+            case 1:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0]);
+                break;
+            case 2:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1]);
+                break;
+            case 3:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2]);
+                break;
+            case 4:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3]);
+                break;
+            case 5:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4]);
+                break;
+            case 6:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5]);
+                break;
+            case 7:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info,  args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6]);
+                break;
+            case 8:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info,  args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7]);
+                break;
+            case 9:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8]);
+                break;
+            case 10:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9]);
+                break;
+            case 11:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10]);
+                break;
+            case 12:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11]);
+                break;
+            case 13:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12]);
+                break;
+            case 14:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13]);
+                break;
+            case 15:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14]);
+                break;
+            case 16:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15]);
+                break;
+            case 17:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16]);
+                break;
+            case 18:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17]);
+                break;
+            case 19:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18]);
+                break;
+            case 20:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]);
+                break;
+            case 21:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20]);
+                break;
+            case 22:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21]);
+                break;
+            case 23:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22]);
+                break;
+            case 24:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23]);
+                break;
+            case 25:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24]);
+                break;
+            case 26:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25]);
+                break;
+            case 27:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26]);
+                break;
+            case 28:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27]);
+                break;
+            case 29:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28]);
+                break;
+            case 30:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]);
+                break;
+            case 31:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30]);
+                break;
+            case 32:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31]);
+                break;
+            case 33:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32]);
+                break;
+            case 34:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33]);
+                break;
+            case 35:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34]);
+                break;
+            case 36:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35]); 
+                break;
+            case 37:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36]); 
+                break;
+            case 38:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37]); 
+                break;
+            case 39:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38]); 
+                break;
+            case 40:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]); 
+                break;
+            case 41:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40]); 
+                break;
+            case 42:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41]); 
+                break;
+            case 43:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42]); 
+                break;
+            case 44:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43]); 
+                break;
+            case 45:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44]); 
+                break;
+            case 46:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45]); 
+                break;
+            case 47:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46]); 
+                break;
+            case 48:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47]); 
+                break;
+            case 49:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48]); 
+                break;
+            case 50:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]); 
+                break;
+            default:
+                AssertMsg(false, "CallFunction call with unsupported number of arguments");
+        }
+//        varResult = arm64_CallFunction((JavascriptFunction*)function, args.Info, args.Values, entryPoint);
 
         return varResult;
     }

--- a/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
+++ b/deps/chakrashim/core/lib/Runtime/Library/JavascriptFunction.cpp
@@ -1419,6 +1419,11 @@ dbl_align:
 #endif
         Js::Var varResult;
 
+//      the switch below to avoid asm variable function invocation which is no more compatible with Apple A12 processor on exception handling
+//      feel free to extend the asm (elegant) solution to support A12 and remove the following implementation
+//        
+//        varResult = arm64_CallFunction((JavascriptFunction*)function, args.Info, args.Values, entryPoint);
+
         unsigned count = args.Info.Count;
         switch(args.Info.Count) 
         {
@@ -1468,189 +1473,1217 @@ dbl_align:
                 break;
             case 11:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10]);
                 break;
             case 12:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11]);
                 break;
             case 13:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                             args.Values[10], args.Values[11], args.Values[12]);
                 break;
             case 14:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                         args.Values[10], args.Values[11], args.Values[12], args.Values[13]);
                 break;
             case 15:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14]);
                 break;
             case 16:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15]);
                 break;
             case 17:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16]);
                 break;
             case 18:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17]);
                 break;
             case 19:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18]);
                 break;
             case 20:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19]);
                 break;
             case 21:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20]);
                 break;
             case 22:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21]);
                 break;
             case 23:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22]);
                 break;
             case 24:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23]);
                 break;
             case 25:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24]);
                 break;
             case 26:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25]);
                 break;
             case 27:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26]);
                 break;
             case 28:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27]);
                 break;
             case 29:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28]);
                 break;
             case 30:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29]);
                 break;
             case 31:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
                                                                             args.Values[30]);
                 break;
             case 32:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9],
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
                                                                             args.Values[30], args.Values[31]);
                 break;
             case 33:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
                                                                             args.Values[30], args.Values[31], args.Values[32]);
                 break;
             case 34:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33]);
                 break;
             case 35:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34]);
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34]);
                 break;
             case 36:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35]); 
                 break;
             case 37:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36]); 
                 break;
             case 38:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37]); 
                 break;
             case 39:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38]); 
                 break;
             case 40:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39]); 
                 break;
             case 41:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40]); 
                 break;
             case 42:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41]); 
                 break;
             case 43:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42]); 
                 break;
             case 44:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43]); 
                 break;
             case 45:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44]); 
                 break;
             case 46:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45]); 
                 break;
             case 47:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46]); 
                 break;
             case 48:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], 
+                                                                            args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47]); 
                 break;
             case 49:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48]); 
                 break;
             case 50:
                 varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
-                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
-                                                                             args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]); 
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49]); 
                 break;
+            case 51:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50]); 
+                break;
+            case 52:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51]); 
+                break;
+            case 53:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52]); 
+                break;
+            case 54:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53]); 
+                break;
+            case 55:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54]); 
+                break;
+            case 56:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55]); 
+                break;
+            case 57:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56]); 
+                break;
+            case 58:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57]); 
+                break;
+            case 59:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58]); 
+                break;
+            case 60:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59]); 
+               break;
+            case 61:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19],
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                                                                                    args.Values[60]); 
+                break;
+            case 62:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61]); 
+                break;
+            case 63:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62]); 
+                break;
+            case 64:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63]); 
+                break;
+            case 65:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39],
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64]); 
+                break;
+            case 66:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65]); 
+                break;
+            case 67:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66]); 
+                break;
+            case 68:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67]); 
+                break;
+            case 69:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68]); 
+                break;
+            case 70:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39],
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69]); 
+               break;    
+            case 71:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70]); 
+                break;
+            case 72:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71]); 
+                break;
+            case 73:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72]); 
+                break;
+            case 74:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73]); 
+                break;
+            case 75:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74]); 
+                break;
+            case 76:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75]); 
+                break;
+            case 77:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76]); 
+                break;
+            case 78:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77]); 
+                break;
+            case 79:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78]); 
+                break;
+            case 80:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79]); 
+               break;                
+            case 81:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80]); 
+                break;
+            case 82:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81]); 
+                break;
+            case 83:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82]); 
+                break;
+            case 84:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83]); 
+                break;
+            case 85:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84]); 
+                break;
+            case 86:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85]); 
+                break;
+            case 87:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86]); 
+                break;
+            case 88:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87]); 
+                break;
+            case 89:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88]); 
+                break;
+            case 90:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89]); 
+               break;  
+            case 91:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90]); 
+                break;
+            case 92:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91]); 
+                break;
+            case 93:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92]); 
+                break;
+            case 94:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93]); 
+                break;
+            case 95:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94]); 
+                break;
+            case 96:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95]); 
+                break;
+            case 97:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96]); 
+                break;
+            case 98:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97]); 
+                break;
+            case 99:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98]); 
+                break;
+            case 100:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99]); 
+               break;                              
+            case 101:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100]); 
+                break;
+            case 102:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101]); 
+                break;
+            case 103:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102]); 
+                break;
+            case 104:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103]); 
+                break;
+            case 105:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104]); 
+                break;
+            case 106:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105]); 
+                break;
+            case 107:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106]); 
+                break;
+            case 108:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107]); 
+                break;
+            case 109:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108]); 
+                break;
+            case 110:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109]); 
+               break;   
+            case 111:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110]); 
+                break;
+            case 112:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111]); 
+                break;
+            case 113:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112]); 
+                break;
+            case 114:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113]); 
+                break;
+            case 115:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114]); 
+                break;
+            case 116:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115]); 
+                break;
+            case 117:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116]); 
+                break;
+            case 118:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117]); 
+                break;
+            case 119:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118]); 
+                break;
+            case 120:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119]); 
+               break;
+            case 121:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120]); 
+                break;
+            case 122:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121]); 
+                break;
+            case 123:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121], args.Values[122]); 
+                break;
+            case 124:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123]); 
+                break;
+            case 125:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124]); 
+                break;
+            case 126:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125]); 
+                break;
+            case 127:
+                varResult = CALL_ENTRYPOINT(function->GetScriptContext()->GetThreadContext(),
+                    entryPoint, (JavascriptFunction*)function, args.Info, args.Values[0], args.Values[1], args.Values[2], args.Values[3], args.Values[4], args.Values[5], args.Values[6], args.Values[7], args.Values[8], args.Values[9], 
+                                                                            args.Values[10], args.Values[11], args.Values[12], args.Values[13], args.Values[14], args.Values[15], args.Values[16], args.Values[17], args.Values[18], args.Values[19], 
+                                                                            args.Values[20], args.Values[21], args.Values[22], args.Values[23], args.Values[24], args.Values[25], args.Values[26], args.Values[27], args.Values[28], args.Values[29], 
+                                                                            args.Values[30], args.Values[31], args.Values[32], args.Values[33], args.Values[34], args.Values[35], args.Values[36], args.Values[37], args.Values[38], args.Values[39], 
+                                                                            args.Values[40], args.Values[41], args.Values[42], args.Values[43], args.Values[44], args.Values[45], args.Values[46], args.Values[47], args.Values[48], args.Values[49], 
+                                                                            args.Values[50], args.Values[51], args.Values[52], args.Values[53], args.Values[54], args.Values[55], args.Values[56], args.Values[57], args.Values[58], args.Values[59],
+                                                                            args.Values[60], args.Values[61], args.Values[62], args.Values[63], args.Values[64], args.Values[65], args.Values[66], args.Values[67], args.Values[68], args.Values[69],
+                                                                            args.Values[70], args.Values[71], args.Values[72], args.Values[73], args.Values[74], args.Values[75], args.Values[76], args.Values[77], args.Values[78], args.Values[79],
+                                                                            args.Values[80], args.Values[81], args.Values[82], args.Values[83], args.Values[84], args.Values[85], args.Values[86], args.Values[87], args.Values[88], args.Values[89],
+                                                                            args.Values[90], args.Values[91], args.Values[92], args.Values[93], args.Values[94], args.Values[95], args.Values[96], args.Values[97], args.Values[98], args.Values[99],
+                                                                            args.Values[100], args.Values[101], args.Values[102], args.Values[103], args.Values[104], args.Values[105], args.Values[106], args.Values[107], args.Values[108], args.Values[109],
+                                                                            args.Values[110], args.Values[111], args.Values[112], args.Values[113], args.Values[114], args.Values[115], args.Values[116], args.Values[117], args.Values[118], args.Values[119],
+                                                                            args.Values[120], args.Values[121], args.Values[122], args.Values[123], args.Values[124], args.Values[125], args.Values[126]); 
+               break;                                           
             default:
                 AssertMsg(false, "CallFunction call with unsupported number of arguments");
         }
-//        varResult = arm64_CallFunction((JavascriptFunction*)function, args.Info, args.Values, entryPoint);
-
         return varResult;
     }
 #else


### PR DESCRIPTION
Fixes the exception handling error on iPhone A12 CPUs.
Replaces the arm64 function invocation call with a C++ unrolled version of it, limited to 256 arguments.

Based on https://github.com/EidosMedia/nodejs-mobile/commit/d4f36d14bfb4740c04d62bc2fd7d73530a0d021e , by https://github.com/DiegoNegri .

Fixes: https://github.com/janeasystems/nodejs-mobile/issues/132

##### Checklist
- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included

##### Affected core subsystem(s)
ios, ChakraCore